### PR TITLE
Add option STATIC_FINDERS_DO_VERIFY_FALLBACK.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytest
 pytest-django
 pytest-pep8
 pytest-cov
+mock

--- a/static_finders.py
+++ b/static_finders.py
@@ -129,7 +129,13 @@ class CompiledStaticsFinder(BaseFinder):
 
 def _fetch_url(url, destination_path):
     _makedirs(destination_path)
-    response = requests.get(url, stream=True)
+    try:
+        response = requests.get(url, stream=True)
+    except Exception:
+        if getattr(settings, 'STATIC_FINDERS_DO_VERIFY_FALLBACK', False):
+            response = requests.get(url, stream=True, verify=False)
+        else:
+            raise
     if response.status_code != 200:
         raise IOError('{} not found'.format(url))
     with open(destination_path, 'wb') as cache:


### PR DESCRIPTION
This is a stopgap feature to get around python 2.7.8's lack of support for SNI certificates.